### PR TITLE
Add script to automatically generate fontawesome.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+icons.yml

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ button.setTypeface(font);
 
 Better font loading techniques for android [here](https://code.google.com/p/android/issues/detail?id=9904#c7)
 
+**How to update:**
+When a new Font Awesome version is released, follow the steps below:
+
+1. Install [Node.js](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
+2. Navigate to this repository's directory and execute `npm install js-yaml`
+3. Download the latest [icons.yaml](https://github.com/FortAwesome/Font-Awesome/blob/master/src/icons.yml) file into the repository's directory
+4. Execute `node generate.js`
+5. That's it! :+1: The `fontawesome.xml` file will now be up-to-date
 
 [Font Awesome](http://fontawesome.io/) or [Font Awesome on GitHub](https://github.com/FortAwesome/Font-Awesome)
 

--- a/generate.js
+++ b/generate.js
@@ -1,0 +1,40 @@
+var fs = require('fs');
+var yaml = require('js-yaml');
+
+// get icons.yml from https://github.com/FortAwesome/Font-Awesome/tree/master/src
+var iconFile = fs.readFileSync('icons.yml', 'utf8')
+var coreIcons = yaml.safeLoad(iconFile).icons; // the official icon list
+var icons = []; // our custom icon list so we can include (and sort) aliases
+
+var output = '<?xml version="1.0" encoding="utf-8"?>\n<resources>\n\n';
+
+// generate our custom list
+coreIcons.forEach(function(i) {
+  icons.push({id: i.id, unicode: i.unicode});
+
+  if (i.aliases) {
+    i.aliases.forEach(function(alias) {
+      icons.push({id: alias, unicode: i.unicode});
+    });
+  }
+});
+
+// sort our custom list
+icons.sort(function(a, b) {
+  if (a.id > b.id) {
+    return 1;
+  }
+  if (a.id < b.id) {
+    return -1;
+  }
+  // a must be equal to b
+  return 0;
+});
+
+icons.forEach(function(i) {
+  var name = i.id.replace(/-/gi, '_');
+  output += '    <item name="fa_' + name + '" type="fontawesome">&#x' + i.unicode + ';</item>\n';
+});
+
+output += '\n</resources>';
+fs.writeFileSync('fontawesome.xml', output, 'utf8');


### PR DESCRIPTION
I wrote this script to generate the pull request from yesterday (https://github.com/edtorba/FontAwesome-Cheatsheet-for-Android/pull/1). It uses Font Awesome's internal icon list as reference, and then outputs a sorted XML file that matches the original `fontawesome.xml`. Instructions have been added to the README.

Feel free to include it if you want it! Should be useful for future updates.
